### PR TITLE
Add camera framebuffer support

### DIFF
--- a/packages/webgl/CHANGELOG.md
+++ b/packages/webgl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @smoovy/webgl
 
+## 1.3.0
+
+### Minor Changes
+
+- feat(webgl): added framebuffer support
+
 ## 1.2.12
 
 ### Patch Changes

--- a/packages/webgl/README.md
+++ b/packages/webgl/README.md
@@ -58,6 +58,12 @@ const camera1 = webgl.camera({ fov: 30});
 const camera2 = webgl.camera({ fov: 30, near: .5, far: 50 });
 ```
 
+Render into a framebuffer texture:
+```js
+const cam1 = webgl.camera('cam1', { framebuffer: true });
+webgl.plane({ textures: cam1.framebuffer.texture });
+```
+
 #### Assign a camera to a mesh
 Meshes will fallback to the default camera. You can overwrite it with the `camera` option:
 

--- a/packages/webgl/demo/index.html
+++ b/packages/webgl/demo/index.html
@@ -16,13 +16,13 @@
   </style>
 </head>
 <body>
-  <div style="width: 500px;height: 500px;background:red;"></div>
+  <!--<div style="width: 500px;height: 500px;background:red;"></div>
   <div style="width: 500px;height: 500px;background:green;"></div>
   <div style="width: 500px;height: 500px;background:brown;"></div>
   <div style="width: 500px;height: 500px;background:gray;"></div>
   <div style="width: 500px;height: 500px;background:purple;"></div>
   <div style="width: 500px;height: 500px;background:salmon;"></div>
-  <div style="width: 500px;height: 500px;background:blue;"></div>
+<div style="width: 500px;height: 500px;background:blue;"></div>-->
   <script async type="module" src="./index.ts"></script>
 </body>
 </html>

--- a/packages/webgl/demo/index.ts
+++ b/packages/webgl/demo/index.ts
@@ -1,165 +1,234 @@
 import { WebGL } from '../src/index';
-import { mapRange } from '../../utils/src/math.ts';
-import lightVertex from './shaders/light.vert.glsl';
-import lightFragment from './shaders/light.frag.glsl';
 
 const src = '/1000x1000.jpg';
-const gl = new WebGL({ uniforms: { u_color1: [0, 1, 0, 1] }  });
-const camera = gl.renderer.camera;
+const gl = new WebGL();
+const c1 = gl.camera({ name: 'fbo', fbo: true });
 
-gl.ctx.disable(gl.ctx.CULL_FACE);
-gl.ctx.enable(gl.ctx.DEPTH_TEST);
-
-const light = gl.plane({
-  width: 40,
-  height: 40,
-  screen: true,
+const p1 = gl.plane({
+  x: 0,
+  y: 0,
+  width: 2,
+  height: 2,
+  camera: c1,
+  uniforms: { u_color: [0,0,0,1] }
 });
 
-//const plane1 = gl.plane({
+//
+//const p2 = gl.plane({
 //  x: 0,
 //  y: 0,
-//  density: 30,
 //  width: 1,
 //  height: 1,
-//  vertex: lightVertex,
-//  fragment: lightFragment,
-//  uniforms: { u_light: light.position }
+//  camera: c1,
+//  uniforms: { u_color: [0,1,0,1] }
 //});
+//
+//const p3 = gl.plane({
+//  x: 1,
+//  y: 0,
+//  width: 1,
+//  height: 1,
+//  camera: c1,
+//  uniforms: { u_color: [0,0,1,1] }
+//})
 
-const plane5 = gl.plane({
-  x: window.innerWidth/2,
-  y: window.innerHeight/2,
+const p0 = gl.plane({
+  x: window.innerWidth*.5,
+  y: window.innerHeight*.5,
   screen: true,
-  width: 500,
-  height: 500,
-  z: 0.1,
-  texture: gl.image({ src, transparent: true }),
-  uniforms: {
-    u_alpha: 0.8,
-  }
-})
+  density: 50,
+  width: window.innerWidth*.5,
+  height: window.innerHeight*.5,
+  uniforms: { u_color: [1,0,0,1] },
+  //camera: c1,
+  //texture: gl.image({ src }),
+  //texture: c1,
+  vertex: `#version 300 es
+    precision mediump float;
 
-const plane6 = gl.plane({
-  x: window.innerWidth/2,
-  y: window.innerHeight/2,
-  screen: true,
-  width: 300,
-  height: 300,
-})
+    in vec4 a_position;
+    in vec2 a_texcoord;
+    uniform float u_time;
+    uniform mat4 u_proj;
+    uniform mat4 u_view;
+    uniform mat4 u_model;
 
-const mouse = { x: 0, y: 0, z: 0 };
+    out vec2 v_texcoord;
+    out vec3 v_normal;
 
-function render(time: number) {
-  //plane1.rotationX = Math.sin(time * 0.001) * -1;
+    void main() {
+      v_texcoord = a_texcoord;
 
-  light.x = mouse.x;
-  light.y = mouse.y;
-  light.z = mouse.z;
+      vec4 pos = a_position;
 
-  requestAnimationFrame(render);
+      pos.z = cos(pos.x*5.5 + u_time)*.2;
+
+      gl_Position = u_proj * u_view * u_model *  pos;
+    }`
+});
+
+window.onresize = () => {
+  p0.x = window.innerWidth*.5;
+  p0.y = window.innerHeight*.5;
+  p0.width = window.innerWidth*.5;
+  p0.height = window.innerHeight*.5;
 }
 
-window.onmousemove = (event) => {
-  mouse.x = event.clientX;
-  mouse.y = event.clientY;
-}
-
-window.onwheel = (event) => {
-  //mouse.z += event.deltaY * 0.01;
-}
-
-requestAnimationFrame(render);
-
- const plane2 = gl.plane({
-   x: 0,
-   y: 1000,
-   width: 500,
-   height: 500,
-   originX: 0,
-   originY: 0,
-   screen: true,
-   texture: gl.video({ src: '/meltdown.mp4' }),
- });
-
- gl.ctx.disable(gl.ctx.CULL_FACE);
-
- setTimeout(() => {
-   function render(time: number) {
-     // plane1.originX = Math.cos(time * .001);
-     // plane2.y = Math.sin(time * .001);
-
-     plane2.width = Math.sin(time * 0.001) * 500;
-     camera.y = camera.ch(window.scrollY);
-
-     requestAnimationFrame(render);
-   }
-
-   render(0);
- }, 100);
-
- let lastX = window.scrollX;
- let lastY = window.scrollY;
-
- window.history.scrollRestoration = 'manual';
-
- const handleScroll = () => {
-   const x = window.scrollX;
-   const y = window.scrollY;
-
-   camera.y = camera.ch(window.scrollY);
-
-   // camera.updateModel();
-   // camera.y = camera.ch(y);
-
-   // camera.projection[13] = camera.ch(y);
-
-   lastX = x;
-   lastY = y;
- }
+//const camera = gl.renderer.camera;
 //
- window.onscroll = () => handleScroll();
- handleScroll();
-// // // settings uniforms
-// // gl.uniforms.mouse = [ 0.5, 0.5 ];
+//gl.ctx.disable(gl.ctx.CULL_FACE);
+//gl.ctx.enable(gl.ctx.DEPTH_TEST);
 //
-// // // creating a texture
-// // const texture1 = gl.image({ source: 'https://picsum.photos/500/500' });
-// // const texture2 = gl.video({ source: 'https://www.w3schools.com/html/mov_bbb.mp4' });
-// // // const fbo1 = gl.fbo();
+//const light = gl.plane({
+//  width: 40,
+//  height: 40,
+//  screen: true,
+//});
 //
-// // // adding a plane
-// // const plane = gl.plane({
-// //   x: 100,
-// //   y: 100,
-// //   width: 500,
-// //   height: 500,
-// //   density: 1000,
-// //   textures: {
-// //     image: texture1,
-// //     video: texture2
-// //   },
-// //   uniforms: {
-// //     color: [ 1, 0, 0, 1 ]
-// //   }
-// // });
+////const plane1 = gl.plane({
+////  x: 0,
+////  y: 0,
+////  density: 30,
+////  width: 1,
+////  height: 1,
+////  vertex: lightVertex,
+////  fragment: lightFragment,
+////  uniforms: { u_light: light.position }
+////});
 //
-// // plane.uniforms.color = [ 0, 0, 1, 1 ];
+//const plane5 = gl.plane({
+//  x: window.innerWidth/2,
+//  y: window.innerHeight/2,
+//  screen: true,
+//  width: 500,
+//  height: 500,
+//  z: 0.1,
+//  texture: gl.image({ src, transparent: true }),
+//  uniforms: {
+//    u_alpha: 0.8,
+//  }
+//})
 //
-// // // plane that covers the screen
-// const viewportPlane = gl.plane({
-//   x: 100,
-//   y: 100,
-//   width: window.innerWidth * .5,
-//   height: window.innerHeight * .5,
+//const plane6 = gl.plane({
+//  x: window.innerWidth/2,
+//  y: window.innerHeight/2,
+//  screen: true,
+//  width: 300,
+//  height: 300,
+//})
+//
+//const mouse = { x: 0, y: 0, z: 0 };
+//
+//function render(time: number) {
+//  //plane1.rotationX = Math.sin(time * 0.001) * -1;
+//
+//  light.x = mouse.x;
+//  light.y = mouse.y;
+//  light.z = mouse.z;
+//
+//  requestAnimationFrame(render);
+//}
+//
+//window.onmousemove = (event) => {
+//  mouse.x = event.clientX;
+//  mouse.y = event.clientY;
+//}
+//
+//window.onwheel = (event) => {
+//  //mouse.z += event.deltaY * 0.01;
+//}
+//
+//requestAnimationFrame(render);
+//
+// const plane2 = gl.plane({
+//   x: 0,
+//   y: 1000,
+//   width: 500,
+//   height: 500,
+//   originX: 0,
+//   originY: 0,
 //   screen: true,
-//   uniforms: {
-//     u_color: [ 0, 0, 1, 0.0 ]
-//   }
+//   texture: gl.video({ src: '/meltdown.mp4' }),
 // });
 //
-// window.addEventListener('scroll', () => {
-//   viewportPlane.y = 100 + window.scrollY;
-//   viewportPlane.uniforms.u_color[3] = Math.min(window.scrollY / window.innerHeight, 1);
-//   viewportPlane.uniforms.u_color[1] = Math.min((window.scrollY - window.innerHeight) / window.innerHeight, 1);
-// });
+// gl.ctx.disable(gl.ctx.CULL_FACE);
+//
+// setTimeout(() => {
+//   function render(time: number) {
+//     // plane1.originX = Math.cos(time * .001);
+//     // plane2.y = Math.sin(time * .001);
+//
+//     plane2.width = Math.sin(time * 0.001) * 500;
+//     camera.y = camera.ch(window.scrollY);
+//
+//     requestAnimationFrame(render);
+//   }
+//
+//   render(0);
+// }, 100);
+//
+// let lastX = window.scrollX;
+// let lastY = window.scrollY;
+//
+// window.history.scrollRestoration = 'manual';
+//
+// const handleScroll = () => {
+//   const x = window.scrollX;
+//   const y = window.scrollY;
+//
+//   camera.y = camera.ch(window.scrollY);
+//
+//   // camera.updateModel();
+//   // camera.y = camera.ch(y);
+//
+//   // camera.projection[13] = camera.ch(y);
+//
+//   lastX = x;
+//   lastY = y;
+// }
+////
+// window.onscroll = () => handleScroll();
+// handleScroll();
+//// // // settings uniforms
+//// // gl.uniforms.mouse = [ 0.5, 0.5 ];
+////
+//// // // creating a texture
+//// // const texture1 = gl.image({ source: 'https://picsum.photos/500/500' });
+//// // const texture2 = gl.video({ source: 'https://www.w3schools.com/html/mov_bbb.mp4' });
+//// // // const fbo1 = gl.fbo();
+////
+//// // // adding a plane
+//// // const plane = gl.plane({
+//// //   x: 100,
+//// //   y: 100,
+//// //   width: 500,
+//// //   height: 500,
+//// //   density: 1000,
+//// //   textures: {
+//// //     image: texture1,
+//// //     video: texture2
+//// //   },
+//// //   uniforms: {
+//// //     color: [ 1, 0, 0, 1 ]
+//// //   }
+//// // });
+////
+//// // plane.uniforms.color = [ 0, 0, 1, 1 ];
+////
+//// // // plane that covers the screen
+//// const viewportPlane = gl.plane({
+////   x: 100,
+////   y: 100,
+////   width: window.innerWidth * .5,
+////   height: window.innerHeight * .5,
+////   screen: true,
+////   uniforms: {
+////     u_color: [ 0, 0, 1, 0.0 ]
+////   }
+//// });
+////
+//// window.addEventListener('scroll', () => {
+////   viewportPlane.y = 100 + window.scrollY;
+////   viewportPlane.uniforms.u_color[3] = Math.min(window.scrollY / window.innerHeight, 1);
+////   viewportPlane.uniforms.u_color[1] = Math.min((window.scrollY - window.innerHeight) / window.innerHeight, 1);
+//// });

--- a/packages/webgl/package.json
+++ b/packages/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smoovy/webgl",
-  "version": "1.2.12",
+  "version": "1.3.0",
   "description": "Easier WebGL animations for websites",
   "main": "./src/index.ts",
   "homepage": "https://github.com/davideperozzi/smoovy",

--- a/packages/webgl/src/camera.ts
+++ b/packages/webgl/src/camera.ts
@@ -1,5 +1,8 @@
 import { mapRange, Size } from '@smoovy/utils';
 
+import { Framebuffer, FramebufferConfig } from './framebuffer';
+import { FramebufferTexture } from './texture';
+
 import { Mat4, mat4, mat4p } from './math';
 import { Model } from './model';
 
@@ -8,6 +11,7 @@ export interface CameraConfig {
   near: number;
   far: number;
   posZ: number;
+  framebuffer?: boolean | Partial<FramebufferConfig>;
 }
 
 export class Camera extends Model {
@@ -15,12 +19,24 @@ export class Camera extends Model {
   readonly view: Size = { width: 1, height: 1 };
   private _projection: Mat4 = mat4();
   private config: CameraConfig;
+  readonly framebuffer?: Framebuffer;
+  readonly texture?: FramebufferTexture;
 
-  constructor(config: Partial<CameraConfig> = {}, view?: Partial<Size>) {
+  constructor(
+    private gl: WebGLRenderingContext,
+    config: Partial<CameraConfig> = {},
+    view?: Partial<Size>
+  ) {
     super();
 
     this.config = { near: .1, far: 100, fov: 45, posZ: -3, ...config };
     this.position.z = this.config.posZ;
+
+    if (config.framebuffer) {
+      const fbConfig = config.framebuffer === true ? {} : config.framebuffer;
+      this.framebuffer = new Framebuffer(gl, fbConfig);
+      this.texture = this.framebuffer.texture;
+    }
 
     this.updateView(view?.width, view?.height);
   }

--- a/packages/webgl/src/framebuffer.ts
+++ b/packages/webgl/src/framebuffer.ts
@@ -14,27 +14,36 @@ export class Framebuffer {
   constructor(private gl: WebGLRenderingContext, config: Partial<FramebufferConfig> = {}) {
     this.texture = new FramebufferTexture(gl, config);
     this.framebuffer = gl.createFramebuffer()!;
-    this.resize(config.width || gl.canvas.width, config.height || gl.canvas.height);
+
+    this.resize(
+      config.width || gl.canvas.width,
+      config.height || gl.canvas.height
+    );
   }
 
-  resize(width: number, height: number) {
+  resize(width = this.size.width, height = this.size.height) {
     const gl = this.gl;
 
     this.size.width = width;
     this.size.height = height;
 
     this.texture.allocate(width, height);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.texture.handle, 0);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    this.bind();
+    gl.framebufferTexture2D(
+      gl.FRAMEBUFFER,
+      gl.COLOR_ATTACHMENT0,
+      gl.TEXTURE_2D,
+      this.texture.handle,
+      0
+    );
+    this.unbind();
   }
 
-  use(cb?: () => void) {
-    const gl = this.gl;
-    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
-    if (cb) {
-      cb();
-    }
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  bind() {
+    this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.framebuffer);
+  }
+
+  unbind() {
+    this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
   }
 }

--- a/packages/webgl/src/framebuffer.ts
+++ b/packages/webgl/src/framebuffer.ts
@@ -23,15 +23,10 @@ export class Framebuffer {
     this.size.width = width;
     this.size.height = height;
 
-    gl.bindTexture(gl.TEXTURE_2D, this.texture.handle);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    this.texture.allocate(width, height);
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.texture.handle, 0);
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    gl.bindTexture(gl.TEXTURE_2D, null);
   }
 
   use(cb?: () => void) {

--- a/packages/webgl/src/framebuffer.ts
+++ b/packages/webgl/src/framebuffer.ts
@@ -1,0 +1,45 @@
+import { Size } from '@smoovy/utils';
+import { FramebufferTexture, FramebufferTextureConfig } from './texture';
+
+export interface FramebufferConfig extends FramebufferTextureConfig {
+  width?: number;
+  height?: number;
+}
+
+export class Framebuffer {
+  readonly texture: FramebufferTexture;
+  private framebuffer: WebGLFramebuffer;
+  readonly size: Size = { width: 0, height: 0 };
+
+  constructor(private gl: WebGLRenderingContext, config: Partial<FramebufferConfig> = {}) {
+    this.texture = new FramebufferTexture(gl, config);
+    this.framebuffer = gl.createFramebuffer()!;
+    this.resize(config.width || gl.canvas.width, config.height || gl.canvas.height);
+  }
+
+  resize(width: number, height: number) {
+    const gl = this.gl;
+
+    this.size.width = width;
+    this.size.height = height;
+
+    gl.bindTexture(gl.TEXTURE_2D, this.texture.handle);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.texture.handle, 0);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+  }
+
+  use(cb?: () => void) {
+    const gl = this.gl;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+    if (cb) {
+      cb();
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  }
+}

--- a/packages/webgl/src/geometry/plane.ts
+++ b/packages/webgl/src/geometry/plane.ts
@@ -178,9 +178,16 @@ export class Plane<C extends PlaneConfig = PlaneConfig> extends Mesh<C> {
     const normals = this.parseNormals(new Float32Array(vertices));
 
     program.attribute('a_position', positions, 3);
-    program.attribute('a_normal', normals, 3, 0);
 
-    if (this.config.texture) {
+    if (program.attribExists('a_normal')) {
+      program.attribute('a_normal', normals, 3, 0);
+    }
+
+    if (this.config.texture || program.attribExists('a_texcoord')) {
+      // Set the size to 3 instead of 2, so we can just us the triangulate function
+      // WebGL will strip away the Z value when it reaches the shader, which is
+      // irrelevant for uvs anyway. Alternatively create a new Flaot32Array with
+      // the z value remvoed
       program.attribute('a_texcoord', triangulate(this.density, false), 3, 0);
     }
   }

--- a/packages/webgl/src/index.ts
+++ b/packages/webgl/src/index.ts
@@ -4,6 +4,7 @@ export * as math from './math';
 export * from './mesh';
 export * from './model';
 export * from './program';
+export * from './framebuffer';
 export * from './renderer';
 export * from './texture';
 export * from './uniform';

--- a/packages/webgl/src/program.ts
+++ b/packages/webgl/src/program.ts
@@ -135,7 +135,7 @@ export class Program {
     offset = 0
   ) {
     this.attribs[name] = {
-      location: this.gl.getAttribLocation(this._program, name),
+      location: this.attribLoc(name),
       buffer: data instanceof Float32Array ? this.bufferData(name, data) : data,
       count,
       norm,
@@ -144,6 +144,14 @@ export class Program {
       size,
       type
     };
+  }
+
+  attribLoc(name: string) {
+    return this.gl.getAttribLocation(this._program, name);
+  }
+
+  attribExists(name: string) {
+    return this.attribLoc(name) !== -1;
   }
 
   bufferData(name: string, data: Float32Array) {

--- a/packages/webgl/src/renderer.ts
+++ b/packages/webgl/src/renderer.ts
@@ -7,7 +7,7 @@ import { UniformValue } from './uniform';
 
 export class Renderer {
   private _resize?: Size;
-  private cameras: Record<string, Camera> = {};
+  private cameras: Camera[] = [];
 
   constructor(
     private gl: WebGLRenderingContext,
@@ -18,29 +18,69 @@ export class Renderer {
     initialSize: Size = { width: 0, height: 0 },
     private uniforms?: Record<string, UniformValue>
   ) {
-    this.cameras.main = new Camera(this.gl, camera || {}, initialSize);
-  }
-
-  get camera() {
-    return this.cameras.main;
+    this.cameras.push(
+      new Camera(this.gl, { name: 'main', active: true, ...camera }, initialSize)
+    );
   }
 
   start() {
     this.ticker.add((_, time) => this.render(time / 1000), this.order);
   }
 
-  addCamera(name: string, camera: Camera) {
-    this.cameras[name] = camera;
+  toggleCamera(nameOrCamera: string | Camera) {
+    let camera = typeof nameOrCamera === 'string'
+      ? this.findCamera(nameOrCamera)
+      : nameOrCamera;
+
+    for (const c of this.cameras) {
+      if (c.framebuffer) {
+        continue;
+      }
+
+      c.active = c === camera;
+    }
+  }
+
+  addCamera(camera: Camera, toggle = false) {
+    this.cameras.push(camera);
+
+    if (toggle) {
+      this.toggleCamera(camera);
+    }
 
     return camera;
   }
 
-  getCamera(name: string) {
-    return this.cameras[name];
+  findCamera(name: string) {
+    return this.cameras.find(camera => camera.name === name);
   }
 
-  removeCamera(name: string) {
-    delete this.cameras[name];
+  hasCamera(nameOrCamera: string) {
+    if (typeof nameOrCamera === 'string') {
+      return !!this.findCamera(nameOrCamera);
+    }
+
+    return this.cameras.includes(nameOrCamera);
+  }
+
+  removeCamera(nameOrCamera: string | Camera) {
+    let camera: Camera | undefined;
+
+    if (typeof nameOrCamera === 'string') {
+      camera = this.findCamera(nameOrCamera);
+    } else {
+      camera = nameOrCamera;
+    }
+
+    const index = this.cameras.findIndex(c => c.name === camera?.name);
+
+    if (index > -1) {
+      this.cameras.splice(index, 1);
+
+      return true;
+    }
+
+    return false;
   }
 
   resize(width: number, height: number, ratio = 1) {
@@ -56,11 +96,8 @@ export class Renderer {
       gl.canvas.height = height;
       gl.viewport(0, 0, width, height);
 
-      for (const camera of Object.values(this.cameras)) {
-        camera.updateView(width, height);
-        if (camera.framebuffer) {
-          camera.framebuffer.resize(width, height);
-        }
+      for (const camera of this.cameras) {
+        camera.resize(width, height);
       }
 
       for (const mesh of this.meshes) {
@@ -71,51 +108,61 @@ export class Renderer {
     }
   }
 
-  render(time = Ticker.now()) {
+  private clearScene() {
+    this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+  }
+
+  private drawMeshes(meshes: Mesh[], time = Ticker.now()) {
     const gl = this.gl;
 
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthMask(true);
+    gl.disable(gl.BLEND);
+
+    for (const mesh of meshes.filter(m => !m.transparent)) {
+      mesh.bind();
+      mesh.draw(time, this.uniforms);
+      mesh.unbind();
+    }
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.depthMask(false);
+
+    const transparentMeshes = meshes
+      .filter(m => m.transparent)
+      .sort((a, b) => a.camDist - b.camDist);
+
+    for (const mesh of transparentMeshes) {
+      mesh.bind();
+      mesh.draw(time, this.uniforms);
+      mesh.unbind();
+    }
+
+    gl.depthMask(true);
+  }
+
+  render(time = Ticker.now()) {
     this.handleResize();
+    this.clearScene();
 
-    for (const camera of Object.values(this.cameras)) {
-      const camMeshes = this.meshes.filter(m => !m.disabled && m.camera === camera);
+    for (const camera of this.cameras) {
+      if (!camera.active) {
+        continue;
+      }
 
-      const drawMeshes = () => {
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-
-        gl.enable(gl.DEPTH_TEST);
-        gl.depthMask(true);
-        gl.disable(gl.BLEND);
-
-        for (const mesh of camMeshes.filter(m => !m.transparent)) {
-          mesh.bind();
-          mesh.draw(time, this.uniforms);
-          mesh.unbind();
-        }
-
-        gl.enable(gl.BLEND);
-        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
-        gl.depthMask(false);
-
-        const transparentMeshes = camMeshes
-          .filter(m => m.transparent)
-          .sort((a, b) => a.camDist - b.camDist);
-
-        for (const mesh of transparentMeshes) {
-          mesh.bind();
-          mesh.draw(time, this.uniforms);
-          mesh.unbind();
-        }
-
-        gl.depthMask(true);
-      };
+      const meshes = this.meshes.filter(m => !m.disabled && m.camera === camera);
 
       camera.draw();
+      camera.bind();
 
       if (camera.framebuffer) {
-        camera.framebuffer.use(drawMeshes);
-      } else {
-        drawMeshes();
+        this.clearScene();
       }
+
+      this.drawMeshes(meshes, time);
+
+      camera.unbind();
     }
   }
 }

--- a/packages/webgl/src/texture.ts
+++ b/packages/webgl/src/texture.ts
@@ -194,4 +194,32 @@ export class VideoTexture extends Texture<VideoTextureConfig> {
   }
 }
 
-export class FramebufferTexture extends Texture<FramebufferTextureConfig> {}
+export class FramebufferTexture extends Texture<FramebufferTextureConfig> {
+  allocate(width: number, height: number) {
+    const gl = this.gl;
+    const wrapS = this.config.wrapS || gl.CLAMP_TO_EDGE;
+    const wrapT = this.config.wrapT || gl.CLAMP_TO_EDGE;
+    const minFilter = this.config.minFilter || gl.LINEAR;
+
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      width,
+      height,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      null
+    );
+    gl.bindTexture(gl.TEXTURE_2D, null);
+
+    if (!this.resolver.completed) {
+      this.resolver.resolve(true);
+    }
+  }
+}

--- a/packages/webgl/src/texture.ts
+++ b/packages/webgl/src/texture.ts
@@ -57,6 +57,10 @@ export class Texture<C extends TextureConfig = TextureConfig> {
     this.texture = gl.createTexture()!;
   }
 
+  get handle() {
+    return this.texture;
+  }
+
   bind(slot = 0, location?: WebGLUniformLocation) {
     const gl = this.gl;
 

--- a/packages/webgl/src/texture.ts
+++ b/packages/webgl/src/texture.ts
@@ -61,6 +61,14 @@ export class Texture<C extends TextureConfig = TextureConfig> {
     return this.texture;
   }
 
+  get uploaded() {
+    return this.resolver.promise;
+  }
+
+  get transparent() {
+    return this.config.transparent;
+  }
+
   bind(slot = 0, location?: WebGLUniformLocation) {
     const gl = this.gl;
 
@@ -97,14 +105,6 @@ export class Texture<C extends TextureConfig = TextureConfig> {
     if ( ! this.resolver.completed) {
       this.resolver.resolve(true);
     }
-  }
-
-  get uploaded() {
-    return this.resolver.promise;
-  }
-
-  get transparent() {
-    return this.config.transparent;
   }
 
   destroy() {}
@@ -216,6 +216,7 @@ export class FramebufferTexture extends Texture<FramebufferTextureConfig> {
       gl.UNSIGNED_BYTE,
       null
     );
+
     gl.bindTexture(gl.TEXTURE_2D, null);
 
     if (!this.resolver.completed) {

--- a/packages/webgl/src/webgl.ts
+++ b/packages/webgl/src/webgl.ts
@@ -211,7 +211,7 @@ export class WebGL extends EventEmitter {
 
     return this.renderer.addCamera(
       name,
-      new Camera(config, this.observable.size)
+      new Camera(this.context, config, this.observable.size)
     );
   }
 

--- a/packages/webgl/src/webgl.ts
+++ b/packages/webgl/src/webgl.ts
@@ -195,7 +195,7 @@ export class WebGL extends EventEmitter {
 
   plane(config: Partial<PlaneConfig> = {}) {
     const plane = new Plane(this.context, {
-      camera: this.renderer.camera,
+      camera: this.renderer.findCamera('main')!,
       ...config
     });
 
@@ -204,14 +204,13 @@ export class WebGL extends EventEmitter {
     return plane;
   }
 
-  camera(name: string, config?: Partial<CameraConfig>) {
-    if ( ! config) {
-      return this.renderer.getCamera(name);
-    }
+  toggleCamera(nameOrCamera: string | Camera) {
+    this.renderer.toggleCamera(nameOrCamera);
+  }
 
+  camera(config: CameraConfig = {}) {
     return this.renderer.addCamera(
-      name,
-      new Camera(this.context, config, this.observable.size)
+      new Camera(this.context, { ...config }, this.observable.size)
     );
   }
 


### PR DESCRIPTION
## Summary
- implement basic `Framebuffer` with resize & use helpers
- allow `Camera` to create optional framebuffer and expose texture
- render using framebuffers when defined and handle camera-specific draws
- resize camera framebuffers with canvas
- forward options in WebGL API
- document framebuffer usage

## Testing
- `yarn lint` *(fails: fetch to yarn registry blocked)*
- `yarn test` *(fails: fetch to yarn registry blocked)*
- `yarn build` *(fails: fetch to yarn registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a8ccf8324832aa936799fb34e4a12